### PR TITLE
Update the version of `drag ruler`

### DIFF
--- a/module.json
+++ b/module.json
@@ -65,7 +65,7 @@
 			{
 				"id": "drag-ruler",
 				"type": "module",
-				"manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-drag-ruler/v1.13.5/module.json"
+				"manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-drag-ruler/develop/module.json"
 			}
 		]
   }


### PR DESCRIPTION
In the current manifest.json, the version of drag ruler is capped at 1.13.5. However, there's a known bug in this version when used with FVTT v11, which causes the distance value to disappear, as noted in this [issue](https://github.com/manuelVo/foundryvtt-drag-ruler/issues/280). The bug was fixed in versions subsequent to 1.13.5. Therefore, we need to update the manifest.json to reflect this.