### PR TITLE
Fix absolute vs relative link bug in module thumbnail image

### DIFF
--- a/module.json
+++ b/module.json
@@ -20,7 +20,7 @@
   "media": [{
         "type": "setup",
         "caption": "PF2E Drag Ruler",
-        "thumbnail": "/modules/pf2e-dragruler/thumbnail.webp"
+        "thumbnail": "modules/pf2e-dragruler/thumbnail.webp"
   }],
   "packs": [
     {


### PR DESCRIPTION
URLs of module assets should not start with `/` (forward backslash), it should be skipped.  When it is included, the image only loads successfully in localhost and in servers that set it up to be in e.g. `www.example.com` but not `www.example.com/myfoundryinstall`.